### PR TITLE
Fixed misplaced quotation mark in String.format()

### DIFF
--- a/plugins/core/mongodb-driver/src/main/java/org/kantega/respiro/mongodb/driver/DefaultMongoDBBuilder.java
+++ b/plugins/core/mongodb-driver/src/main/java/org/kantega/respiro/mongodb/driver/DefaultMongoDBBuilder.java
@@ -50,7 +50,7 @@ public class DefaultMongoDBBuilder implements MongoDBBuilder {
         for (String a : addresses) {
             String address[] = a.split(":");
             if (address.length < 2)
-                throw new RuntimeException(String.format("Server address cannot be split into host and port '%s', a"));
+                throw new RuntimeException(String.format("Server address cannot be split into host and port '%s'", a));
 
             srvAddresses.add(new ServerAddress(address[0], Integer.valueOf(address[1])));
         }


### PR DESCRIPTION
Currently a `MissingFormatArgumentException` is thrown when attempting to throw a RuntimeException